### PR TITLE
Fix payload too large

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version="0.3", features = ["env-filter"] }
 tower = { version = "0.4.0" }
-tower-http = { version = "0.4.0", features = ["trace"] }
+tower-http = { version = "0.4.0", features = ["trace", "limit"] }
 
 [dev-dependencies]
 tempfile = "3.7.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,13 +59,16 @@ async fn main() {
         .unwrap();
 }
 
+/// 250MB limit
+const REQUEST_BODY_LIMIT: usize = 250 * 1024 * 1024;
+
 fn app(args: Arc<Args>) -> Router {
     Router::new()
         .route("/", get(index).post(accept_form))
         .route("/scripts.js", get(scripts))
         .layer(Extension(args))
         .layer(DefaultBodyLimit::disable())
-        .layer(RequestBodyLimitLayer::new(250 * 1024 * 1024)) // 250MB limit
+        .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
         .layer(tower_http::trace::TraceLayer::new_for_http())
 }
 
@@ -252,7 +255,7 @@ mod test {
                         CONTENT_TYPE,
                         "multipart/form-data;boundary=95685543938383789682253523760123",
                     )
-                    .header(CONTENT_LENGTH, "1000000000")
+                    .header(CONTENT_LENGTH, REQUEST_BODY_LIMIT + 1)
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use axum::{
 };
 use clap::Parser;
 use rust_embed::RustEmbed;
+use tower_http::limit::RequestBodyLimitLayer;
 use tracing::{error, info};
 
 #[derive(Parser)]
@@ -63,7 +64,8 @@ fn app(args: Arc<Args>) -> Router {
         .route("/", get(index).post(accept_form))
         .route("/scripts.js", get(scripts))
         .layer(Extension(args))
-        .layer(DefaultBodyLimit::max(250 * 1024 * 1024)) // 250MB limit
+        .layer(DefaultBodyLimit::disable())
+        .layer(RequestBodyLimitLayer::new(250 * 1024 * 1024)) // 250MB limit
         .layer(tower_http::trace::TraceLayer::new_for_http())
 }
 


### PR DESCRIPTION
Previously the server would just panic internally and reset the connection. By using `RequestBodyLimitLayer` we get a proper `413 Payload Too Large` error.